### PR TITLE
update yaxpeax worker to 1.0

### DIFF
--- a/bench/yaxpeax/Cargo.toml
+++ b/bench/yaxpeax/Cargo.toml
@@ -16,8 +16,8 @@ lto = true
 
 [features]
 decoder = []
-formatter = []
+formatter = ["yaxpeax-x86/fmt"]
 
 [dependencies]
-yaxpeax-x86 = { path = "../../libs/yaxpeax", version = "*", default-features = false, features = ["std"] }
-yaxpeax-arch = { version = "*", default-features = false }
+yaxpeax-x86 = { path = "../../libs/yaxpeax", version = "1.0.0", default-features = false, features = ["std"] }
+yaxpeax-arch = { version = "0.2.0", default-features = false }


### PR DESCRIPTION
hello again! i've released [yaxpeax-x86 1.0](https://crates.io/crates/yaxpeax-x86/1.0.0) including avx2 and avx512 support, and a few changes to decoder interfaces. in the process i've seen pretty significant improvements in decoding performance, so i figure it'd a good time to make sure disas-bench is updated!

this is a benchmark run from this commit, on my ryzen 3590x. i think it's representative and suitable for use in this repo. but, if there's something else to bench on that you feel is more representative, i'd love an external check of these results! :) ![bench](https://user-images.githubusercontent.com/4615790/124404035-04747400-dcee-11eb-87cc-0d7fb00ff57c.png)