### PR TITLE
Update bddisasm to v3.0.0 and add bddisasm mini bench

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -52,6 +52,7 @@ targets = [
     ['bench/distorm/bench-distorm-fmt', 'diStorm decode+fmt'],
     ['bench/iced-x86/bench-iced-fmt', 'iced decode+fmt'],
     ['bench/bddisasm/bench-bddisasm-fmt', 'bddisasm decode+fmt'],
+    ['bench/bddisasm/bench-bddisasm-mini-fmt', 'bddisasm mini decode+fmt'],
     ['bench/yaxpeax/bench-yaxpeax-fmt', 'yaxpeax decode+fmt'],
     ['bench/sleigh/bench-sleigh-fmt', 'sleigh decode+fmt'],
 
@@ -62,6 +63,7 @@ targets = [
     ['bench/distorm/bench-distorm-no-fmt', 'diStorm decode'],
     ['bench/iced-x86/bench-iced-no-fmt', 'iced decode'],
     ['bench/bddisasm/bench-bddisasm-no-fmt', 'bddisasm decode'],
+    ['bench/bddisasm/bench-bddisasm-mini-no-fmt', 'bddisasm mini decode'],
     ['bench/yaxpeax/bench-yaxpeax-no-fmt', 'yaxpeax decode'],
 ]
 timings = []

--- a/bench/bddisasm/.gitignore
+++ b/bench/bddisasm/.gitignore
@@ -1,2 +1,4 @@
 bench-bddisasm-fmt
 bench-bddisasm-no-fmt
+bench-bddisasm-mini-fmt
+bench-bddisasm-mini-no-fmt

--- a/bench/bddisasm/Makefile
+++ b/bench/bddisasm/Makefile
@@ -1,6 +1,19 @@
+CC := cc
+CFLAGS := -O3 -I../../libs/bddisasm/inc
+LDFLAGS := -L../../libs/bddisasm/build -lbddisasm
+
 make-bench-bddisasm:
-	cc main.c -O3 -o bench-bddisasm-fmt -I../../libs/bddisasm/inc -L../../libs/bddisasm/bin/x64/Release -lbddisasm
-	cc main.c -O3 -o bench-bddisasm-no-fmt -DDISAS_BENCH_NO_FORMAT -I../../libs/bddisasm/inc -L../../libs/bddisasm/bin/x64/Release -lbddisasm
+	$(CC) main.c $(CFLAGS) $(LDFLAGS) \
+	    -o bench-bddisasm-fmt
+	$(CC) main.c $(CFLAGS) $(LDFLAGS) \
+	    -DDISAS_BENCH_NO_FORMAT \
+	    -o bench-bddisasm-no-fmt
+	$(CC) main.c $(CFLAGS) $(LDFLAGS) \
+	    -DDISASM_BENCH_USE_BDD_MINI \
+	    -o bench-bddisasm-mini-fmt
+	$(CC) main.c $(CFLAGS) $(LDFLAGS) \
+	    -DDISASM_BENCH_USE_BDD_MINI -DDISAS_BENCH_NO_FORMAT \
+	    -o bench-bddisasm-mini-no-fmt
 
 clean:
-	rm -f bench-bddisasm-fmt bench-bddisasm-no-fmt
+	rm -f bench-bddisasm-fmt bench-bddisasm-no-fmt bench-bddisasm-mini-fmt bench-bddisasm-mini-no-fmt

--- a/bench/bddisasm/main.c
+++ b/bench/bddisasm/main.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include "../load_bin.inc"
 
-#include "disasmtypes.h"
 #include "bddisasm.h"
 
 int nd_vsnprintf_s(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr)
@@ -60,12 +59,12 @@ int main(int argc, char* argv[])
     clock_t end_time = clock();
 
     printf(
-        "Disassembled %zu instructions (%zu valid, %zu bad), %.2f ms\n", 
+        "Disassembled %zu instructions (%zu valid, %zu bad), %.2f ms\n",
         num_valid_insns + num_bad_insn,
         num_valid_insns,
         num_bad_insn,
         (double)(end_time - start_time) * 1000.0 / CLOCKS_PER_SEC
     );
-    
+
     return 0;
 }

--- a/make-all.sh
+++ b/make-all.sh
@@ -95,11 +95,8 @@ fi
 
 echo "[*] Building bddisasm ..."
 cd libs/bddisasm
-if [[ "$is_windows" == "y" ]]; then
-    msbuild.exe bddisasm/bddisasm.vcxproj -p:Configuration=Release -p:Platform=x64
-else
-    $make
-fi
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBDD_INCLUDE_TOOL=OFF -DBDD_INCLUDE_ISAGENERATOR_X86=OFF -DBDD_LTO=ON
+cmake --build build --target bddisasm
 cd ../..
 
 # Build benchmark tools


### PR DESCRIPTION
This updates `bddisasm` to the latest version and adds a benchmark for the new `NdDecodeMini` API.